### PR TITLE
Added support for Vector Storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ const onGenerationAfterCommands = async (type, config, dryRun) => {
 };
 
 const toggleVisibilityAllMessages = async (state = true) => {
-    hideChatMessageRange(0, chat.length - 1, state);
+	hideChatMessageRange(0, chat.length - 1, state);
 }
 
 const onGroupMemberDrafted = async (type, charId) => {
@@ -182,11 +182,11 @@ const onGroupMemberDrafted = async (type, charId) => {
 	if (type == "impersonate" || chat_metadata.ignore_presence?.includes(char)) {
 		debug("Impersonation detected");
 		//reveal all history for impersonation
-        toggleVisibilityAllMessages(true);
+        	toggleVisibilityAllMessages(true);
 	} else {
 		//handle NPC draft
 		//hide all messages
-        toggleVisibilityAllMessages(false);
+		toggleVisibilityAllMessages(false);
 
 		const messages = chat.map((m, i) => ({ id: i, present: m.present ?? [] })).filter((m) => m.present.includes(char));
 
@@ -332,7 +332,7 @@ eventSource.on(event_types.GENERATION_AFTER_COMMANDS, async (...args) => {
 const messageReceived = async (...args) => {
 	log("MESSAGE_RECEIVED", args);
 	onNewMessage(...args);
-    toggleVisibilityAllMessages(true);
+	toggleVisibilityAllMessages(true);
 	return;
 };
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
-import { characters, chat, chat_metadata, eventSource, event_types, getCurrentChatId, saveChatDebounced, saveSettingsDebounced } from "../../../../script.js";
-import { groups, is_group_generating, selected_group } from "../../../../scripts/group-chats.js";
+import { chat, chat_metadata, getCurrentChatId, characters, saveChatDebounced, eventSource, event_types, saveSettingsDebounced } from "../../../../script.js";
+import { groups, selected_group, is_group_generating } from "../../../../scripts/group-chats.js";
 import { hideChatMessageRange } from "../../../chats.js";
 import { extension_settings } from "../../../extensions.js";
+import { commonEnumProviders } from "../../../slash-commands/SlashCommandCommonEnumsProvider.js";
 import { SlashCommand } from "../../../slash-commands/SlashCommand.js";
 import { ARGUMENT_TYPE, SlashCommandArgument } from "../../../slash-commands/SlashCommandArgument.js";
-import { commonEnumProviders } from "../../../slash-commands/SlashCommandCommonEnumsProvider.js";
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
 
 const extensionName = "Presence";
 
 const extensionNameLong = `SillyTavern-${extensionName}`;
 const extensionFolderPath = `scripts/extensions/third-party/${extensionNameLong}`;
-const extensionSettings = { ...extension_settings[extensionName] };
+const extensionSettings = extension_settings[extensionName];
 const defaultSettings = {
 	enabled: true,
 	location: "top",

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
-import { chat, chat_metadata, getCurrentChatId, characters, saveChatDebounced, eventSource, event_types, saveSettingsDebounced } from "../../../../script.js";
-import { groups, selected_group, is_group_generating } from "../../../../scripts/group-chats.js";
+import { characters, chat, chat_metadata, eventSource, event_types, getCurrentChatId, saveChatDebounced, saveSettingsDebounced } from "../../../../script.js";
+import { groups, is_group_generating, selected_group } from "../../../../scripts/group-chats.js";
 import { hideChatMessageRange } from "../../../chats.js";
 import { extension_settings } from "../../../extensions.js";
-import { commonEnumProviders } from "../../../slash-commands/SlashCommandCommonEnumsProvider.js";
 import { SlashCommand } from "../../../slash-commands/SlashCommand.js";
 import { ARGUMENT_TYPE, SlashCommandArgument } from "../../../slash-commands/SlashCommandArgument.js";
+import { commonEnumProviders } from "../../../slash-commands/SlashCommandCommonEnumsProvider.js";
 import { SlashCommandParser } from "../../../slash-commands/SlashCommandParser.js";
 
 const extensionName = "Presence";
 
 const extensionNameLong = `SillyTavern-${extensionName}`;
 const extensionFolderPath = `scripts/extensions/third-party/${extensionNameLong}`;
-const extensionSettings = extension_settings[extensionName];
+const extensionSettings = { ...extension_settings[extensionName] };
 const defaultSettings = {
 	enabled: true,
 	location: "top",


### PR DESCRIPTION
These are the changes:
- The method for the "MESSAGE_RECEIVED" event was modified to be executed at the beginning, before the Vector Storage call.
- The method for the "MESSAGE_SENT" event was modified to be executed at the end, after the Vector Storage call.
- The "toggleVisibilityAllMessages" method was added to avoid repeating code and replaced where it was used.

The issue:
Since Presence hides messages to filter them, when Vector Storage starts vectorizing the chat, it deletes all hidden messages that existed in the database.

The solution:
Have Presence change visibility states outside of Vector Storage calls.