### PR TITLE
Fixed the issue when the extension did not work with empty settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,13 @@ const extensionName = "Presence";
 
 const extensionNameLong = `SillyTavern-${extensionName}`;
 const extensionFolderPath = `scripts/extensions/third-party/${extensionNameLong}`;
-const extensionSettings = extension_settings[extensionName];
 const defaultSettings = {
 	enabled: true,
 	location: "top",
 	debugMode: false,
 	seeLast: true,
 };
+let extensionSettings = extension_settings[extensionName];
 
 
 const log = (...msg) => console.log("[" + extensionName + "]", ...msg);
@@ -30,7 +30,8 @@ const debug = (...msg) => {
 
 const initSettings = async () => {
 	if (!extensionSettings || extensionSettings == {}) {
-		extensionSettings[extensionName] = defaultSettings;
+        extension_settings[extensionName] = defaultSettings;
+        extensionSettings = extension_settings[extensionName];
 		saveSettingsDebounced();
 	} else if (extensionSettings.enabled == undefined) {
 		extensionSettings[extensionName] = { ...defaultSettings, ...extensionSettings };

--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ const debug = (...msg) => {
 const initSettings = async () => {
 	if (!extensionSettings || extensionSettings == {}) {
         extension_settings[extensionName] = defaultSettings;
-        extensionSettings = extension_settings[extensionName];
+        extensionSettings = defaultSettings;
 		saveSettingsDebounced();
 	} else if (extensionSettings.enabled == undefined) {
-		extensionSettings[extensionName] = { ...defaultSettings, ...extensionSettings };
+        extension_settings[extensionName] = { ...defaultSettings, ...extensionSettings };
 		saveSettingsDebounced();
 	}
 };


### PR DESCRIPTION
### Issue

When running the extension for the first time, an error appears in the console, and the extension doesn't work.
![Screenshot of bug](https://github.com/user-attachments/assets/a5a3475a-8cf2-43a3-88c0-471affbc103d)

### Steps to Reproduce

1. Remove the "Presence" section from the SillyTavern user settings file, typically located at `data/default-user/settings.json`.
2. Reload the SillyTavern UI page.

### Solution

Assign the settings directly to the `extension_settings` variable and then link them with the `extensionSettings` variable.