### PR TITLE
Fix command help strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,23 @@ It really is that simple!
   
 Okay, but really here's how it works.  
 SillyTavern has two kinds of chats and this plugin works differently for both:  
-  
+
 ### Individual chats
 If you're talking one on one with a character then this plugin will do nothing, nudda.  
 It simple disables itself if you are not in a group chat.  
-  
+
 ### Group chats
 In a group chat this plugin will restrict each character's memory to what they were there for.  
 This is done by hiding all messages that they don't remember.  
 
 Each message will have a little icon for each character who was 'present' for that message.  
 ![little icons to show who is present](images/small-icons.png)  
-  
+
 You can control who is 'present' (i.e. who remembers things) by enabling or disabling automatic replies from that character.  
 Characters remember two things:   
 	- 1 messages they were present for   
 	- 2 the message directly before the one they are replying to, this is only short in short term memory while they are "typing" but moves to long term memory when their message actually gets sent.  
-  
+
 You can also change who was present for a message after it is recieved, hover over the little icons that show who was present and they will expand and show an icon for everyone whether they were there or not. Just click an icon to change whether that character was present.  
 ![big icons you can click to toggle](images/large-icons.png)  
 
@@ -37,9 +37,16 @@ Click this button and it lights up, that will indicate that this character can s
 
 
 ### Commands
-Currently there is only one command.  
-	/presenceforget "Character name"  
-This command COMPLETELY and IRREVERSIBLY wipes the memory of the given character.  
+
+`/presenceForceAllPresent` makes all characters remember EVERYTHING.
+
+`/presenceForceNonePresent` makes all characters forget EVERYTHING.
+
+`/presenceForget <char_name>` wipes the memory of the character.
+
+`/presenceRememberAll <char_name>` adds all messages to the memory of the character.
+
+These commands IRREVERSIBLY toggles ALL messages to the memory of the given character(s).
 
 
 

--- a/index.js
+++ b/index.js
@@ -417,7 +417,7 @@ SlashCommandParser.addCommandObject(
 				enumProvider: commonEnumProviders.characters("all"),
 			}),
 		],
-		helpString: "Wipes the memory of a character. Usage /presenceForget <name>",
+		helpString: "Wipes the memory of a character. Usage: /presenceForget char_name",
 	})
 );
 
@@ -441,7 +441,7 @@ SlashCommandParser.addCommandObject(
 				enumProvider: commonEnumProviders.characters("all"),
 			}),
 		],
-		helpString: "Adds all messages to the memory of a character. Usage /presenceRememberAll <name>",
+		helpString: "Adds all messages to the memory of a character. Usage: /presenceRememberAll char_name",
 	})
 );
 
@@ -452,7 +452,7 @@ SlashCommandParser.addCommandObject(
 			await commandForceAllPresent(args);
 			return "";
 		},
-		helpString: "Makes all characters remember EVERYTHING. Usage /presenceForceAllPresent <name>",
+		helpString: "Makes all characters remember EVERYTHING.",
 	})
 );
 
@@ -463,7 +463,7 @@ SlashCommandParser.addCommandObject(
 			await commandForceNonePresent(args);
 			return "";
 		},
-		helpString: "Makes all characters remember EVERYTHING. Usage /presenceForceNonePresent <name>",
+		helpString: "Makes all characters forget EVERYTHING.",
 	})
 );
 


### PR DESCRIPTION
* Correct help string for `/presenceForceNonePresent`: remember > forget.
* Change \<name> to char_name since \<name> is invisible in UI (prepending \ doesn't work so idk how to preserve this).
* Remove redundant Usage text for argless commands.

![image](https://github.com/user-attachments/assets/32961c82-8de0-4a7a-84a5-fd9df3353e22)